### PR TITLE
hotfix: 영웅호걸이 들어가있는 경우, 게임모드 실행이 안되는 문제 해결

### DIFF
--- a/modules/ui.js
+++ b/modules/ui.js
@@ -113,6 +113,10 @@ const createTokenArea = (cardData) => {
     const tokenArea = document.createElement('div');
     tokenArea.className = CSS_CLASSES.TOKEN_AREA;
 
+    if (!cardData) {
+        return tokenArea;
+    }
+
     if (cardData.ammunition > 0) {
         tokenArea.appendChild(createResourceTracker(cardData, 'ammunition'));
     }
@@ -150,6 +154,13 @@ const createTokenArea = (cardData) => {
 };
 
 const createActionButtons = (cardData, unitData) => {
+    // 비어있는 슬롯을 placeholder로 표시
+    if (!cardData) {
+        const placeholder = document.createElement('div');
+        placeholder.className = CSS_CLASSES.ACTION_BUTTON_PLACEHOLDER;
+        return placeholder;
+    }
+
     const hasButton = (cardData.drop || (cardData.changes && cardData.changes.length > 0));
     if (!hasButton) {
         const placeholder = document.createElement('div');


### PR DESCRIPTION
### 작업내용

영웅호걸이가 로스터에 하나라도 들어가 있는 경우, 게임모드 자체가 실행이 안되는 문제 해결

null 값에 대해 placeholder 랜더링 하는 방식으로 해결

## 기타

-> 실제 게임 룰과 달리, 파일럿이 비어도, 부품이 여러개 없어도 (심지어 하나도 없어도) 게임모드는 실행됩니다.
근데 이건 향후 앱 기획 방향으로 잡으시면 되고, 일단 저는 아예 실행이 안되는 문제만 해결 했습니다.

## 사진

<img width="710" height="621" alt="스크린샷 2025-09-18 오후 3 08 05" src="https://github.com/user-attachments/assets/f38518f1-5e71-4242-839b-1ccd3250c874" />
